### PR TITLE
Add html closing tag in example html block.

### DIFF
--- a/2_settingup.rst
+++ b/2_settingup.rst
@@ -58,7 +58,8 @@ Open a file called ``userinfo_lulu.html``, and save it to the ``templates`` dire
         
       </div>
     </div>
-
+    </html>
+    
 Once the HTML file is written, you can view it in a web browser.  You can do this from command line.  For example, on a Mac::
 
      open -a /Applications/Google\ Chrome.app/ userinfo_lulu.html


### PR DESCRIPTION
In my case, I needed to have this closing tag to be able to open the html in the browser (the example that follows)